### PR TITLE
Have Travis operate concurrently on all plugins.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: java
 jdk:
   - oraclejdk8
-
+env:
+  - ENVTARGET=ofmeet
+  - ENVTARGET=ofsocial
+  - ENVTARGET=ofswitch
 script: 
-  - ant -f ofmeet/build.xml jar
-  - ant -f ofsocial/build.xml jar  
-  - ant -f ofswitch/build.xml jar    
+  - ant -f $ENVTARGET/build.xml jar
 


### PR DESCRIPTION
This change tricks Travis into believing that it's building the same project for three different environments. Instead, it's building three different plugins.