### PR TITLE
some responsive design changes

### DIFF
--- a/ofmeet/src/app.js
+++ b/ofmeet/src/app.js
@@ -246,7 +246,7 @@ function obtainAudioAndVideoPermissions(callback) {
                     });
                     messageHandler.showError("Error",
                         "Failed to obtain permissions to use the local microphone" +
-                            "and/or camera.");
+                            " and/or camera.");
                 }
             );
         },

--- a/ofmeet/src/css/main.css
+++ b/ofmeet/src/css/main.css
@@ -20,8 +20,9 @@ html, body{
     top: 0px;
     bottom: 0px;
     right: 0px;
-    width: 20%;
-    max-width: 200px;
+//    width: 20%;
+//    max-width: 200px;
+    width:200px !important;
     overflow: hidden;
     /* background-color:#dfebf1;*/
     background-color:#FFFFFF;

--- a/ofmeet/src/css/videolayout_default.css
+++ b/ofmeet/src/css/videolayout_default.css
@@ -346,7 +346,7 @@
     margin-right:auto;
     padding-left:2px;
     padding-right:2px;
-    height:38px;
+//    height:38px;
     width:auto;
     background-color: rgba(0,0,0,0.8); 
     border: 1px solid rgba(256, 256, 256, 0.2);

--- a/ofmeet/src/ofmuc.js
+++ b/ofmeet/src/ofmuc.js
@@ -117,7 +117,7 @@ Strophe.addConnectionPlugin('ofmuc', {
         var availableWidth = Util.getAvailableVideoWidth();
         var availableHeight = this.getPresentationHeight();
 
-        var aspectRatio = 16.0 / 9.0;
+        var aspectRatio = 16.5 / 9.0;
         if (availableHeight < availableWidth / aspectRatio) {
             availableWidth = Math.floor(availableHeight * aspectRatio);
         }

--- a/ofmeet/src/side_panel_toggler.js
+++ b/ofmeet/src/side_panel_toggler.js
@@ -229,9 +229,9 @@ var PanelToggler = (function(my) {
         var availableWidth = window.innerWidth;
 
         var panelWidth = 200;
-        if (availableWidth * 0.2 < 200) {
-            panelWidth = availableWidth * 0.2;
-        }
+//        if (availableWidth * 0.2 < 200) {
+//            panelWidth = availableWidth * 0.2;
+//        }
 
         return [panelWidth, availableHeight];
     };


### PR DESCRIPTION
As per @marclaporte request, i decided to try to incorporate some responsive design to openfire meetings because that is something that is lacking.

There were some stuff i didnt quite understand and some stuff that i couldnt modify (like other plugins include in ofmeet) so the changes for now are minimal.

Some of the changes are:
changed the aspect ratio for the presentation window to make the horizontal scrollbar disappear.
make the chat side panel always be at 200px instead of 20% of the width of the screen. (important on mobile)
remove fixed height for the toolbar, useful when the toolbar takes 2 rows on mobile

Its not much but i feel if i do to much i may modify stuff that i shouldnt (and maybe i already did :P) 